### PR TITLE
se agregaron interacciones y animacion para cavar

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -106,6 +106,11 @@ move_down={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
 ]
 }
+left_click={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
 
 [rendering]
 

--- a/scenes/enano.tscn
+++ b/scenes/enano.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://jl85rkt7u6yw"]
+[gd_scene load_steps=18 format=3 uid="uid://jl85rkt7u6yw"]
 
 [ext_resource type="Script" path="res://script_enano.gd" id="1_2lpd2"]
 [ext_resource type="Texture2D" uid="uid://dupqbku5s1jfk" path="res://assets/Dwarf Miner Sprite Sheet.png" id="2_eljh1"]
@@ -54,12 +54,34 @@ tracks/0/keys = {
 "values": [Vector2i(0, 1), Vector2i(1, 1), Vector2i(2, 1), Vector2i(3, 1), Vector2i(4, 1), Vector2i(5, 1), Vector2i(6, 1), Vector2i(7, 1)]
 }
 
+[sub_resource type="Animation" id="Animation_5vt7q"]
+resource_name = "cavar"
+length = 0.56
+loop_mode = 1
+step = 0.01
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CharacterBody2D/pivote/Sprite2D:frame_coords")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.07, 0.14, 0.21, 0.28, 0.35, 0.42, 0.49),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
+"update": 1,
+"values": [Vector2i(0, 2), Vector2i(1, 2), Vector2i(2, 2), Vector2i(3, 2), Vector2i(4, 2), Vector2i(5, 2), Vector2i(6, 2), Vector2i(7, 2)]
+}
+
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_gnyql"]
 _data = {
 "RESET": SubResource("Animation_gnc8e"),
+"cavar": SubResource("Animation_5vt7q"),
 "idle": SubResource("Animation_gcsy8"),
 "move": SubResource("Animation_04v2x")
 }
+
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_rortw"]
+animation = &"cavar"
 
 [sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_b41rs"]
 animation = &"idle"
@@ -74,12 +96,18 @@ animation = &"move"
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_g34m3"]
 advance_mode = 2
 
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_b3s4l"]
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_vjbh8"]
+
 [sub_resource type="AnimationNodeStateMachine" id="AnimationNodeStateMachine_11obg"]
+states/cavar/node = SubResource("AnimationNodeAnimation_rortw")
+states/cavar/position = Vector2(621.333, 160.42)
 states/idle/node = SubResource("AnimationNodeAnimation_b41rs")
 states/idle/position = Vector2(392, 93.1111)
 states/move/node = SubResource("AnimationNodeAnimation_gbbdj")
-states/move/position = Vector2(630.667, 92.6667)
-transitions = ["idle", "move", SubResource("AnimationNodeStateMachineTransition_mj1p2"), "move", "idle", SubResource("AnimationNodeStateMachineTransition_kgqgv"), "Start", "idle", SubResource("AnimationNodeStateMachineTransition_g34m3")]
+states/move/position = Vector2(630.667, 93.7037)
+transitions = ["idle", "move", SubResource("AnimationNodeStateMachineTransition_mj1p2"), "move", "idle", SubResource("AnimationNodeStateMachineTransition_kgqgv"), "Start", "idle", SubResource("AnimationNodeStateMachineTransition_g34m3"), "idle", "cavar", SubResource("AnimationNodeStateMachineTransition_b3s4l"), "cavar", "idle", SubResource("AnimationNodeStateMachineTransition_vjbh8")]
 
 [node name="enano" type="Node2D"]
 

--- a/script_enano.gd
+++ b/script_enano.gd
@@ -8,6 +8,7 @@ var gravity = 0
 @onready var animation_tree: AnimationTree = $AnimationTree
 @onready var playback = animation_tree.get("parameters/playback")
 @onready var pivote: Node2D = $pivote
+@onready var character_body_2d: CharacterBody2D = $"."
 
 
 # Called when the node enters the scene tree for the first time.
@@ -36,8 +37,28 @@ func _physics_process(delta: float) -> void:
 
 	move_and_slide()
 
-	#animation
+	#animation movimiento
 	if abs(velocity.x) > 10 :
+		playback.travel("move")
+	elif abs(velocity.y) > 10 :
 		playback.travel("move")
 	else:
 		playback.travel("idle")
+		
+	if Input.is_action_pressed("left_click"):
+		var target_position = get_global_mouse_position()
+		var distance = position.distance_to(target_position)
+		var posicion_enano = character_body_2d.global_transform.origin #obtener posicion del enano
+		var rango_cavar = 100  # Establece tu rango de ataque
+		if distance <= rango_cavar:
+			if target_position.x - posicion_enano.x < 0:
+				pivote.scale.x = -1
+			elif pivote.scale.x == -1 and target_position.x - posicion_enano.x > 0 :
+				pivote.scale.x = 1
+			print("cavar")
+			print(target_position.x - posicion_enano.x)
+			playback.travel("cavar")
+			#aqui toca configurar el ataque y perdidas de vida
+		else:
+			print("fuera de rango")
+


### PR DESCRIPTION
Se añadieron interacciones con el click para cavar junto a la animación de cavar, la animación solo te activara cuando se este haciendo click derecho dentro de un pequeño radio (100 unidades) al rededor del enano.
La animación esta configurada para que el enano se gire si intenta cavar algo detrás de el.
La animación se aprecia al mantener el click apretado (la animación dura cerca de 0,5s), se espera que tome al menos este tiempo como mínimo para romper un bloque así que de momento esto no es un problema.